### PR TITLE
issue-32-add-function-to-update-the-value-for-the-deprecated-status-of-items

### DIFF
--- a/colectica_api/api.py
+++ b/colectica_api/api.py
@@ -783,6 +783,7 @@ class ColecticaBasicAPI:
             ]``. All three of agencyId, identifier and version must be
             specified in order for the deprecation status of an item to be
             updated.
+
         Keyword Args:
             State: (boolean/None): if omitted, item's deprecated state is
                 set to 'false'.

--- a/colectica_api/api.py
+++ b/colectica_api/api.py
@@ -764,6 +764,53 @@ class ColecticaBasicAPI:
             if response.json() != []:
                 return response.json()
 
+    def update_state(
+        self,
+        AgencyId,
+        Identifier,
+        *,
+        Version=None,
+        State=False,
+        ApplyToAllVersions=True
+    ):
+        """Updates the Deprecated State of a set of items
+        Args:
+            AgencyId (str): For example, ``"uk.cls.nextsteps"``.
+            Identifier (str): e.g., ``"a6f96245-5c00-4ad3-89e9-79afaefa0c28"``.
+          
+        Keyword Args:
+            Version (int/None): if omitted, first make a call to
+                retrieve the latest version.
+            State: (boolean/None): if omitted, item's deprecated state is
+                set to 'false'.
+            ApplyToAllVersions: if omitted, all versions of item have their
+                deprecation status updated.    
+        
+        Returns:
+            HTTP status code indicating success or failure of operation, e.g.
+            success=200
+        """
+        if Version is None:
+            Version = self.get_item_json(AgencyId, Identifier)["Version"]
+        query = {
+            "ids": [
+                {
+                "agencyId": AgencyId,
+                "identifier": Identifier,
+                "version": Version
+                }
+            ],
+            "state": State,
+            "applyToAllVersions": ApplyToAllVersions
+        }
+        
+        url = f"https://{self.host}/api/v1/item/_updateState"
+        response = requests.post(url, headers=self.token, json=query, verify=self.verify)
+        if response.ok:
+            return response
+        raise ValueError(
+            f"Server returned {response.status_code} error: {response.content}"
+        )
 
 if __name__ == "__main__":
     raise RuntimeError("don't run this directly")

--- a/colectica_api/api.py
+++ b/colectica_api/api.py
@@ -768,7 +768,6 @@ class ColecticaBasicAPI:
         self,
         items,
         *,
-        Version=None,
         State=False,
         ApplyToAllVersions=True
     ):
@@ -798,6 +797,30 @@ class ColecticaBasicAPI:
 
         Documented here: https://docs.colectica.com/portal/technical/api/v1/#tag/Item/paths/~1api~1v1~1item~1_updateState/post
         """
+
+        items_lower_case_fields = [{key.lower(): value for key, value in dictionary.items()} for dictionary in items]
+        itemsWithNoAgencyId=[i for i, e in enumerate(['agencyid' in x for x in items_lower_case_fields]) if e == False]
+        
+        itemsWithNoIdentifier=[i for i, e in enumerate(['identifier' in x for x in items_lower_case_fields]) if e == False]
+        
+        itemsWithNoVersion=[i for i, e in enumerate(['version' in x for x in items_lower_case_fields]) if e == False]
+        
+        if (len(itemsWithNoAgencyId)>0):
+            print("\nThe following item(s) did not have an agency id specified: ")
+            print([items[i] for i in itemsWithNoAgencyId])
+
+        if (len(itemsWithNoIdentifier)>0):
+            print("\nThe following item(s) did not have an identifier specified: ")
+            print([items[i] for i in itemsWithNoIdentifier])
+                
+        if (len(itemsWithNoVersion)>0):
+            print("\nThe following item(s) did not have a version specified: ")
+            print([items[i] for i in itemsWithNoVersion])
+            
+        if (len(itemsWithNoAgencyId)>0 or len(itemsWithNoIdentifier)>0 or len(itemsWithNoVersion)>0):
+            print("\nPlease ensure that all elements in the items array contain agencyId, identifier, and version fields.")
+            return    
+
         query = {
             "ids": items,
             "state": State,

--- a/colectica_api/api.py
+++ b/colectica_api/api.py
@@ -771,7 +771,8 @@ class ColecticaBasicAPI:
         State=False,
         ApplyToAllVersions=True
     ):
-        """Updates the Deprecated State of a set of items
+        """Updates the Deprecated State of a set of items.
+        
         Args:
             items: For example, ``[
                 {

--- a/colectica_api/api.py
+++ b/colectica_api/api.py
@@ -772,7 +772,7 @@ class ColecticaBasicAPI:
         ApplyToAllVersions=True
     ):
         """Updates the Deprecated State of a set of items.
-        
+
         Args:
             items: For example, ``[
                 {
@@ -806,21 +806,22 @@ class ColecticaBasicAPI:
         
         itemsWithNoVersion=[i for i, e in enumerate(['version' in x for x in items_lower_case_fields]) if e == False]
         
+        errorDetails = ""
+
         if (len(itemsWithNoAgencyId)>0):
-            print("\nThe following item(s) did not have an agency id specified: ")
-            print([items[i] for i in itemsWithNoAgencyId])
+            errorDetails+=("The following item(s) did not have an agency id specified: ")
+            errorDetails+=str([items[i] for i in itemsWithNoAgencyId]) + ". "
 
         if (len(itemsWithNoIdentifier)>0):
-            print("\nThe following item(s) did not have an identifier specified: ")
-            print([items[i] for i in itemsWithNoIdentifier])
+            errorDetails+=("The following item(s) did not have an identifier specified: ")
+            errorDetails+=str([items[i] for i in itemsWithNoIdentifier]) + ". "
                 
         if (len(itemsWithNoVersion)>0):
-            print("\nThe following item(s) did not have a version specified: ")
-            print([items[i] for i in itemsWithNoVersion])
+            errorDetails+=("The following item(s) did not have a version specified: ")
+            errorDetails+=str([items[i] for i in itemsWithNoVersion]) + ". "
             
         if (len(itemsWithNoAgencyId)>0 or len(itemsWithNoIdentifier)>0 or len(itemsWithNoVersion)>0):
-            print("\nPlease ensure that all elements in the items array contain agencyId, identifier, and version fields.")
-            return    
+            raise KeyError(errorDetails + "Please ensure that all elements in the items array contain agencyId, identifier, and version fields.")
 
         query = {
             "ids": items,

--- a/colectica_api/api.py
+++ b/colectica_api/api.py
@@ -766,8 +766,7 @@ class ColecticaBasicAPI:
 
     def update_state(
         self,
-        AgencyId,
-        Identifier,
+        items,
         *,
         Version=None,
         State=False,
@@ -775,12 +774,16 @@ class ColecticaBasicAPI:
     ):
         """Updates the Deprecated State of a set of items
         Args:
-            AgencyId (str): For example, ``"uk.cls.nextsteps"``.
-            Identifier (str): e.g., ``"a6f96245-5c00-4ad3-89e9-79afaefa0c28"``.
-          
+            items: For example, ``[
+                {
+                    "agencyId": "uk.closer",
+                    "identifier": "9da68988-f9e4-48b3-996b-fbcbd3c5d1f6",
+                    "version": 2
+                }
+            ]``. All three of agencyId, identifier and version must be
+            specified in order for the deprecation status of an item to be
+            updated.
         Keyword Args:
-            Version (int/None): if omitted, first make a call to
-                retrieve the latest version.
             State: (boolean/None): if omitted, item's deprecated state is
                 set to 'false'.
             ApplyToAllVersions: if omitted, all versions of item have their
@@ -790,16 +793,8 @@ class ColecticaBasicAPI:
             HTTP status code indicating success or failure of operation, e.g.
             success=200
         """
-        if Version is None:
-            Version = self.get_item_json(AgencyId, Identifier)["Version"]
         query = {
-            "ids": [
-                {
-                "agencyId": AgencyId,
-                "identifier": Identifier,
-                "version": Version
-                }
-            ],
+            "ids": items,
             "state": State,
             "applyToAllVersions": ApplyToAllVersions
         }

--- a/colectica_api/api.py
+++ b/colectica_api/api.py
@@ -793,6 +793,10 @@ class ColecticaBasicAPI:
         Returns:
             HTTP status code indicating success or failure of operation, e.g.
             success=200
+    
+        This uses the ``/api/v1/item/_updateState`` API call.
+
+        Documented here: https://docs.colectica.com/portal/technical/api/v1/#tag/Item/paths/~1api~1v1~1item~1_updateState/post
         """
         query = {
             "ids": items,


### PR DESCRIPTION
Add function to api.py that allows requests to be sent to the 'updateState' REST API function. Note that items for which we wish to update the deprecation status are specified as an array of objects with agency id/identifier/version. This allows the function to be used to deprecate sets of items, not just an individual item specified using function arguments.